### PR TITLE
Profile entries may not include URLs

### DIFF
--- a/src/nix/profile_list.rs
+++ b/src/nix/profile_list.rs
@@ -45,21 +45,6 @@ pub struct ProfileListV2Element {
     /// How is an element 'deactivated'?
     pub active: bool,
 
-    /// `home-mangler.grandiflora.packages`
-    ///
-    /// Why is there no `original_attr_path`?
-    pub attr_path: String,
-
-    /// `git+file:///Users/wiggles/.dotfiles?dir=config/home-mangler`
-    ///
-    /// TODO: When does this differ from `url`?
-    pub original_url: String,
-
-    /// `null` or `["man"]`
-    ///
-    /// Doesn't seem to include the default output `out`. Or maybe that's only if it's `null`?
-    pub outputs: Option<Vec<String>>,
-
     /// 5
     pub priority: u16,
 
@@ -67,5 +52,20 @@ pub struct ProfileListV2Element {
     pub store_paths: Vec<Utf8PathBuf>,
 
     /// `git+file:///Users/wiggles/.dotfiles?dir=config/home-mangler`
-    pub url: String,
+    pub url: Option<String>,
+
+    /// `home-mangler.grandiflora.packages`
+    ///
+    /// Why is there no `original_attr_path`?
+    pub attr_path: Option<String>,
+
+    /// `git+file:///Users/wiggles/.dotfiles?dir=config/home-mangler`
+    ///
+    /// TODO: When does this differ from `url`?
+    pub original_url: Option<String>,
+
+    /// `null` or `["man"]`
+    ///
+    /// Doesn't seem to include the default output `out`. Or maybe that's only if it's `null`?
+    pub outputs: Option<Vec<String>>,
 }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -82,8 +82,9 @@ impl ProfileList {
         match &self {
             ProfileList::V2(packages) => {
                 for (i, package) in packages.iter().enumerate() {
-                    if package.attr_path == attr_path
-                        && package.original_url == flake.metadata.original_url
+                    if package.attr_path.as_deref() == Some(attr_path)
+                        && package.original_url.as_deref()
+                            == Some(flake.metadata.original_url.as_str())
                     {
                         indices_to_remove.push(i);
                         paths_to_remove.extend(package.store_paths.iter().map(|p| p.as_path()));


### PR DESCRIPTION
It is possible to `nix profile install` store paths directly, and these entries show up when a `nix-env` profile is converted to a `nix profile` profile.