### PR TITLE
Remove `darwin.apple_sdk` inputs

### DIFF
--- a/nix/packages/home-mangler.nix
+++ b/nix/packages/home-mangler.nix
@@ -3,7 +3,6 @@
   lib,
   stdenv,
   libiconv,
-  darwin,
   inputs,
   rustPlatform,
   rust-analyzer,
@@ -17,7 +16,6 @@
     nativeBuildInputs = lib.optionals stdenv.isDarwin [
       # Additional darwin specific inputs can be set here
       libiconv
-      darwin.apple_sdk.frameworks.CoreServices
     ];
 
     meta = {


### PR DESCRIPTION
```
trace: evaluation warning: darwin.apple_sdk_11_0.CoreServices: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
```